### PR TITLE
Add static Next.js phishing warning demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
 # SecureWarningView
+
+GitHub Pages에 배포할 수 있는 Next.js 기반의 정적 경고 페이지 예제입니다. `example.com`과 같이 피싱 위험이 있는 도메인을 사칭하는 사이트라는 설정으로, 사용자에게 즉각적인 경고 메시지를 강조하는 UI를 제공합니다.
+
+## 주요 특징
+
+- **정적 Export 지원**: `next.config.mjs`에서 `output: "export"`를 사용해 GitHub Pages에 올릴 수 있는 순수 정적 파일을 생성합니다.
+- **접근성 고려**: `role="alert"`, `aria-live="assertive"` 등 스크린 리더 사용자도 경고를 인지할 수 있도록 접근성 속성을 포함했습니다.
+- **어두운 테마의 경고 UI**: 강렬한 색상과 애니메이션을 통해 위험 경고를 시각적으로 강조합니다.
+
+## 개발 환경 구성
+
+```bash
+npm install
+```
+
+### 개발 서버 실행
+
+```bash
+npm run dev
+```
+
+`http://localhost:3000`에서 개발 서버가 실행되며, 수정 사항을 실시간으로 확인할 수 있습니다.
+
+### 프로덕션 빌드 및 정적 Export
+
+```bash
+npm run build
+npm run export
+```
+
+명령이 완료되면 `out/` 디렉터리에 GitHub Pages에 업로드할 수 있는 정적 파일이 생성됩니다.
+
+## GitHub Pages 배포 예시
+
+1. 리포지터리를 GitHub에 푸시합니다.
+2. GitHub Pages 설정에서 **Build and deployment** → **Source**를 `Deploy from a branch`로 설정합니다.
+3. `gh-pages` 등 배포용 브랜치를 하나 만들고, `out/` 디렉터리의 정적 파일을 해당 브랜치의 루트에 커밋합니다.
+   - 예: `npm run build && npm run export` 이후 `git subtree push --prefix out origin gh-pages`
+4. 저장하면 수 분 내에 GitHub Pages 주소에서 경고 페이지를 확인할 수 있습니다.
+
+> GitHub Pages의 서브디렉터리에 배포하는 경우(예: `https://username.github.io/repo-name`)에는 `next.config.mjs`의 `basePath`와 `assetPrefix`를 저장소 이름에 맞게 지정하세요.
+
+## 라이선스
+
+이 프로젝트는 학습 및 데모 목적으로 자유롭게 사용할 수 있습니다.
+

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,11 @@
+const config = {
+  output: "export",
+  distDir: "out",
+  reactStrictMode: true,
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "secure-warning-view",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "export": "next export",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import "../styles/globals.css";
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,51 @@
+import Head from "next/head";
+
+const warningItems = [
+  "이 사이트는 금융 정보를 탈취하려는 피싱 페이지입니다.",
+  "절대로 개인정보나 비밀번호를 입력하지 마세요.",
+  "브라우저를 즉시 닫고 공식 고객센터를 통해 사실 여부를 확인하세요.",
+];
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>위험한 피싱 사이트 경고</title>
+        <meta
+          name="description"
+          content="사용자를 속여 정보를 빼내려는 악성 피싱 사이트 경고 페이지"
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <main className="page">
+        <section className="warning-card" role="alert" aria-live="assertive">
+          <div className="warning-badge" aria-hidden="true">
+            <span className="warning-icon">⚠️</span>
+          </div>
+          <h1 className="warning-title">경고: 악성 피싱 사이트</h1>
+          <p className="warning-subtitle">
+            이 사이트는 example.com 도메인을 사칭하여 사용자의 민감 정보를 탈취하려고 시도하고 있습니다.
+          </p>
+          <ul className="warning-list">
+            {warningItems.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <a
+            className="cta-button"
+            href="https://www.kisa.or.kr/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            한국인터넷진흥원(KISA)에서 더 알아보기
+          </a>
+        </section>
+      </main>
+      <footer className="footer">
+        <p>
+          이 페이지는 보안 교육 목적으로 제공되는 데모이며 실제 피싱 사이트가 아닙니다.
+        </p>
+      </footer>
+    </>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: dark;
+  font-family: "Pretendard", "Noto Sans KR", "Malgun Gothic", "Apple SD Gothic Neo", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #050608;
+  color: #f8fafc;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1f2937 0%, #050608 55%, #020205 100%);
+}
+
+.page {
+  min-height: calc(100vh - 120px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 3rem 1.5rem;
+}
+
+.warning-card {
+  width: min(720px, 100%);
+  border-radius: 28px;
+  padding: 3rem 2.5rem;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(31, 41, 55, 0.7));
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  box-shadow: 0 40px 100px rgba(248, 113, 113, 0.45);
+  text-align: center;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.warning-badge {
+  width: 100px;
+  height: 100px;
+  border-radius: 28px;
+  margin: 0 auto;
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.3), rgba(127, 29, 29, 0.7));
+  border: 1px solid rgba(248, 113, 113, 0.8);
+  display: grid;
+  place-items: center;
+  transform: rotate(-6deg);
+  box-shadow: inset 0 0 30px rgba(250, 204, 21, 0.2), 0 25px 60px rgba(248, 113, 113, 0.35);
+}
+
+.warning-icon {
+  font-size: 3rem;
+  transform: rotate(6deg);
+}
+
+.warning-title {
+  font-size: clamp(2.25rem, 4vw, 2.75rem);
+  margin: 0;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: #fda4af;
+  text-shadow: 0 0 30px rgba(248, 113, 113, 0.45);
+}
+
+.warning-subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.warning-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.warning-list li {
+  position: relative;
+  padding-left: 2rem;
+  font-size: 1rem;
+  line-height: 1.6;
+  text-align: left;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.warning-list li::before {
+  content: "";
+  position: absolute;
+  left: 0.25rem;
+  top: 0.7rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #f87171, #facc15);
+  box-shadow: 0 0 18px rgba(248, 113, 113, 0.8);
+}
+
+.cta-button {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.95rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #f87171, #facc15);
+  color: #0f172a;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 20px 45px rgba(248, 113, 113, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 65px rgba(248, 113, 113, 0.55);
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 600px) {
+  .warning-card {
+    padding: 2.5rem 1.75rem;
+  }
+
+  .warning-list li {
+    padding-left: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a minimal Next.js project configured for static export and GitHub Pages deployment
- implement a dark-themed phishing warning landing page with accessibility considerations
- document local development, build, and deployment steps in the README

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e14b8e9cc4832a9035ebfcd0bb3aa6